### PR TITLE
define __STDC_FORMAT_MACROS before inttypes.h

### DIFF
--- a/platform/Platform.h.in
+++ b/platform/Platform.h.in
@@ -25,6 +25,7 @@
 @FIXEDINT_IMPL@
 @FIXEDINT_128_IMPL@
 @FIXEDINT_SEEDT_IMPL@
+#define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
With gcc There is the need to defined that macro or all that \`PRIu64' formats don't work.


more on it
[#18719205](https://stackoverflow.com/questions/14535556/why-doesnt-priu64-work-in-this-code#18719205)
[#385151](https://bugs.gentoo.org/395151)
